### PR TITLE
[spark] Reject ALTER TABLE REPLACE COLUMNS to avoid silent data corruption

### DIFF
--- a/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
+++ b/paimon-spark/paimon-spark-common/src/main/java/org/apache/paimon/spark/SparkCatalog.java
@@ -350,16 +350,54 @@ public class SparkCatalog extends SparkBaseCatalog
     @Override
     public org.apache.spark.sql.connector.catalog.Table alterTable(
             Identifier ident, TableChange... changes) throws NoSuchTableException {
-        List<SchemaChange> schemaChanges =
-                Arrays.stream(changes).map(this::toSchemaChange).collect(Collectors.toList());
+        org.apache.paimon.catalog.Identifier identifier = toIdentifier(ident, catalogName);
         try {
-            catalog.alterTable(toIdentifier(ident, catalogName), schemaChanges, false);
+            if (isReplaceColumns(changes)) {
+                throw new UnsupportedOperationException(
+                        "ALTER TABLE ... REPLACE COLUMNS is not supported for Paimon tables. "
+                                + "Please use RENAME COLUMN, ALTER COLUMN TYPE, DROP COLUMN, "
+                                + "and ADD COLUMN instead.");
+            }
+
+            List<SchemaChange> schemaChanges =
+                    Arrays.stream(changes).map(this::toSchemaChange).collect(Collectors.toList());
+            catalog.alterTable(identifier, schemaChanges, false);
             return loadTable(ident);
         } catch (Catalog.TableNotExistException e) {
             throw new NoSuchTableException(ident);
         } catch (Catalog.ColumnAlreadyExistException | Catalog.ColumnNotExistException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * Detects whether the given changes originate from an {@code ALTER TABLE ... REPLACE COLUMNS}
+     * statement.
+     *
+     * <p>Spark translates {@code REPLACE COLUMNS} into a batch that drops every existing column and
+     * re-adds the new set, i.e. a combination of {@link TableChange.DeleteColumn} and {@link
+     * TableChange.AddColumn} only. Other column changes such as rename or type update are never
+     * produced by {@code REPLACE COLUMNS}, so we match exclusively on these two types to avoid
+     * mistaking a legitimate mixed batch (e.g. a programmatic DROP + RENAME) for a replace.
+     *
+     * <p>This operation must be rejected because re-adding columns assigns brand-new field ids while
+     * existing data files keep the old ids; same-named columns would then be treated as new columns
+     * and read back as null, silently corrupting data.
+     */
+    private boolean isReplaceColumns(TableChange[] changes) {
+        boolean hasDeleteColumn = false;
+        boolean hasAddColumn = false;
+        for (TableChange change : changes) {
+            if (change instanceof TableChange.DeleteColumn) {
+                hasDeleteColumn = true;
+            } else if (change instanceof TableChange.AddColumn) {
+                hasAddColumn = true;
+            } else {
+                return false;
+            }
+        }
+
+        return hasDeleteColumn && hasAddColumn;
     }
 
     @Override

--- a/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
+++ b/paimon-spark/paimon-spark-ut/src/test/java/org/apache/paimon/spark/SparkSchemaEvolutionITCase.java
@@ -249,6 +249,23 @@ public class SparkSchemaEvolutionITCase extends SparkReadTestBase {
     }
 
     @Test
+    public void testReplaceColumnsUnsupported() {
+        createTable("testReplaceColumnsUnsupported");
+
+        assertThatThrownBy(
+                        () ->
+                                spark.sql(
+                                        "ALTER TABLE testReplaceColumnsUnsupported REPLACE COLUMNS "
+                                                + "(a BIGINT, bb STRING, c STRING)"))
+                .satisfies(
+                        anyCauseMatches(
+                                UnsupportedOperationException.class,
+                                "ALTER TABLE ... REPLACE COLUMNS is not supported for Paimon tables. "
+                                        + "Please use RENAME COLUMN, ALTER COLUMN TYPE, DROP COLUMN, "
+                                        + "and ADD COLUMN instead."));
+    }
+
+    @Test
     public void testDropPartitionKey() {
         spark.sql(
                 "CREATE TABLE testDropPartitionKey (\n"


### PR DESCRIPTION
## Summary

Spark translates `ALTER TABLE ... REPLACE COLUMNS` into a batch that drops every existing column and re-adds the new set (a combination of `DeleteColumn` + `AddColumn`). For Paimon this is unsafe: re-adding columns assigns brand-new field ids while existing data files keep the old ids, so same-named columns are treated as new columns and read back as `null` — a silent data corruption.

This PR detects that change pattern in `SparkCatalog.alterTable` and throws an `UnsupportedOperationException` with a clear message pointing users to `RENAME COLUMN` / `ALTER COLUMN TYPE` / `DROP COLUMN` / `ADD COLUMN` instead.

The detection matches exclusively on `DeleteColumn` + `AddColumn` so a legitimate mixed batch (e.g. a programmatic DROP + RENAME) is not mistaken for a replace.

## Tests

Added `SparkSchemaEvolutionITCase#testReplaceColumnsUnsupported` verifying the operation is rejected with the expected exception.